### PR TITLE
Mas Options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.0.4
+
+- Add additional command line options
+
 ## 0.0.3
 
 - Don't pass invalid Haml file through, so it doesn't end up in your `gulp.dest`.

--- a/README.md
+++ b/README.md
@@ -9,14 +9,12 @@ installed to use this. Try `gem install haml`. If you use
 ## Options
 
 ### style
-
 Output style. Can be indented (default) or ugly.
 
 `{style: ugly}`
 
 
 ### format
-
 Output format. Can be html5 (default), xhtml, or html4.
 
 `{format: "xhtml"}`

--- a/README.md
+++ b/README.md
@@ -10,73 +10,46 @@ installed to use this. Try `gem install haml`. If you use
 
 ### style
 Output style. Can be indented (default) or ugly.
-
 `{style: ugly}`
-
 
 ### format
 Output format. Can be html5 (default), xhtml, or html4.
-
 `{format: "xhtml"}`
 
-
 ### require
-
 Require additional ruby files. Same as 'ruby -r'.
-
 `{require: "./my_haml_helpers.rb"}`
 
-
 ### escapeHtml
-
 Escape HTML characters (like ampersands and angle brackets) by default.
-
 `{escapeHtml: true}`
 
-
 ### noEscapeAttrs
-
 Don't escape HTML characters (like ampersands and angle brackets) in attributes.
-
 `{noEscapeAttrs: true}`
 
-
 ### doubleQuoteAttributes
-
 Set attribute wrapper to double-quotes (default is single).
-
 `{doubleQuote: true}`
 
-
 ### trace
-
 Show a full traceback on error
-
 `{trace: true}`
 
-
 ### unixNewlines (false)
-
 Use Unix-style newlines in written files.
-
 `{unixNewlines: true}`
 
 ### cdata
-
 Always add CDATA sections to javascript and css blocks.
-
 `{cdata: true}`
 
 ### autoclose
-
 List of elements to be automatically self-closed.
-
 `{autoclose: ["img", "input", "br", ...]}`
 
 ### loadPath
-
 specify $LOAD_PATH directory (may be used more than once). Same as 'ruby -I'.
-
 `{loadPath: "my/load/path"}`
 
 ## gulpfile.js example

--- a/README.md
+++ b/README.md
@@ -8,8 +8,78 @@ installed to use this. Try `gem install haml`. If you use
 
 ## Options
 
-Pass `{doubleQuote: true}` to use `"` around HTML attributes instead of `'`.
-This uses the `-q`/`--double-quote-attributes` option with `haml`.
+### style
+
+Output style. Can be indented (default) or ugly.
+
+`{style: ugly}`
+
+
+### format
+
+Output format. Can be html5 (default), xhtml, or html4.
+
+`{format: "xhtml"}`
+
+
+### require
+
+Require additional ruby files. Same as 'ruby -r'.
+
+`{require: "./my_haml_helpers.rb"}`
+
+
+### escapeHtml
+
+Escape HTML characters (like ampersands and angle brackets) by default.
+
+`{escapeHtml: true}`
+
+
+### noEscapeAttrs
+
+Don't escape HTML characters (like ampersands and angle brackets) in attributes.
+
+`{noEscapeAttrs: true}`
+
+
+### doubleQuoteAttributes
+
+Set attribute wrapper to double-quotes (default is single).
+
+`{doubleQuote: true}`
+
+
+### trace
+
+Show a full traceback on error
+
+`{trace: true}`
+
+
+### unixNewlines (false)
+
+Use Unix-style newlines in written files.
+
+`{unixNewlines: true}`
+
+### cdata
+
+Always add CDATA sections to javascript and css blocks.
+
+`{cdata: true}`
+
+### autoclose
+
+List of elements to be automatically self-closed.
+
+`{autoclose: ["img", "input", "br", ...]}`
+
+### loadPath
+
+specify $LOAD_PATH directory (may be used more than once). Same as 'ruby -I'.
+
+`{loadPath: "my/load/path"}`
 
 ## gulpfile.js example
 

--- a/index.js
+++ b/index.js
@@ -18,7 +18,6 @@ module.exports = function (opt) {
     }
 
     if (file.isStream()) {
-      // Use stdin?
       this.emit('error',
                 new PluginError(PLUGIN_NAME, 'Streaming not supported'));
       return callback(null, file);

--- a/test/fixtures/basic.haml
+++ b/test/fixtures/basic.haml
@@ -1,0 +1,3 @@
+-%p Hello world!
+-%a{href: 'http://example.com'} Example
+-%div{ng: {include: "'tpl.html'"}}

--- a/test/fixtures/basic.haml
+++ b/test/fixtures/basic.haml
@@ -1,3 +1,0 @@
-%p Hello world!
-%a{href: 'http://example.com'} Example
-%div{ng: {include: "'tpl.html'"}}


### PR DESCRIPTION
Added additional options available in the command line tool (found through haml --help) and updated the docs to reflect verbiage from those docs. Also added doubleQuoteAttributes (along sound doubleQuote) for consistency.  Did not add tests to this yet so take it for what it is.