### PR TITLE
Add haml -r feature to support view helper feature

### DIFF
--- a/index.js
+++ b/index.js
@@ -23,11 +23,16 @@ module.exports = function (opt) {
     var options = {};
     options.outExtension = opt.outExtension || '.html';
     options.doubleQuote = opt.doubleQuote || false;
+    options.require = opt.require || false;
 
     var str = file.contents.toString('utf8');
     var args = ['haml'];
     if (options.doubleQuote) {
       args.push('-q');
+    }
+    if(options.require) {
+      args.push('-r');
+      args.push(options.require);
     }
     args.push(file.path);
     var cp = spawn(args.shift(), args);

--- a/test/fixtures/view_helper.haml
+++ b/test/fixtures/view_helper.haml
@@ -1,0 +1,3 @@
+%p= hello_world
+%a{href: 'http://example.com'} Example
+%div{ng: {include: "'tpl.html'"}}

--- a/test/test.js
+++ b/test/test.js
@@ -95,3 +95,29 @@ describe('invalid Haml', function() {
     });
   });
 });
+
+describe('basic Haml with view_helper', function() {
+  var in_path = path.join(fixture_dir, 'view_helper.haml');
+
+  gulp.task('view-helper-haml', function() {
+    return gulp.src(in_path).
+                pipe(haml({require: ["./test/view_helper.rb"]})).
+                pipe(gulp.dest(dest_dir));
+  });
+
+  it('compiles Haml into HTML', function (done) {
+    var out_path = path.join(dest_dir, 'view_helper.html');
+    gulp.run('view-helper-haml', function() {
+      assert.equal(fs.existsSync(out_path), true,
+                   'Expected ' + out_path + ' to exist');
+      var out_contents = fs.readFileSync(out_path);
+      var expected = "<p>Hello world!</p>\n" +
+                     "<a href='http://example.com'>Example</a>\n" +
+                     "<div ng-include=\"'tpl.html'\"></div>\n";
+      assert.equal(out_contents, expected, 'Haml was not compiled as expected');
+      fs.unlink(out_path, function (err) {});
+      done();
+    });
+  });
+});
+

--- a/test/view_helper.rb
+++ b/test/view_helper.rb
@@ -1,0 +1,7 @@
+module ViewHelper
+  def hello_world
+    "Hello world!"
+  end
+end
+
+include ViewHelper


### PR DESCRIPTION
Hello,

I think add require feature to gulp-ruby-haml will make generate website more easier and more faster.
I also try use `gulp-ziey-ruby-haml` but it didn't work correctly, due to it modify many codes from gulp-ruby-haml.

But I notice this repo seems no longer update any issue and pull-request, I hope this feature can merge as soon as possible.