### PR TITLE
Addresses https://github.com/moneypenny/gulp-ruby-haml/issues/10

### DIFF
--- a/index.js
+++ b/index.js
@@ -26,10 +26,10 @@ module.exports = function (opt) {
 
     var str = file.contents.toString('utf8');
     var args = ['haml'];
+    args.push('-s');
     if (options.doubleQuote) {
       args.push('-q');
     }
-    args.push(file.path);
     var cp = spawn(args.shift(), args);
 
     var self = this;
@@ -62,6 +62,9 @@ module.exports = function (opt) {
       newFile.contents = new Buffer(haml_data);
       return callback(null, newFile);
     });
+
+    cp.stdin.write(file.contents);
+    cp.stdin.end();
   }
 
   return through.obj(modifyFile);


### PR DESCRIPTION
This patch will allow the haml() plugin to process haml without requiring it to exist on the physical disk.

Instead of supplying the haml command with the path of an input file, we supply the switch -s, and write the haml to childprocess.stdin. This lets us do the following (for instance)

<pre><code>
gulp.src('foo/bar/**/*.haml')
  .pipe(replace('albert', 'dilbert'))
  .pipe(haml())
  .pipe(gulp.dest('baz'));
</code></pre>

Earlier, since (the current version) plugin works by passing the absolute path of the haml source file, one would first have to write the output of replace to a temp folder.